### PR TITLE
Use subclass instead of class_alias

### DIFF
--- a/librarygenerator.php
+++ b/librarygenerator.php
@@ -121,8 +121,8 @@ if(!ini_get('user_agent')) ini_set('user_agent', 'Mozilla/5.0 (Macintosh; U; Int
     parent::__construct(\$wsdl, \$options);
 EOD;
 	$aliascode = <<<EOD
-class_alias("{$serviceName}", "{$oldServiceName}");
-?>
+	class {$oldServiceName} extends {$serviceName} {}
+	?>
 EOD;
 	$file = str_replace($oldServiceName, $serviceName, $file);
 	$file = str_replace("parent::__construct(\$wsdl, \$options);", $constructorcode, $file);

--- a/services/Appointment_Service.php
+++ b/services/Appointment_Service.php
@@ -176,5 +176,5 @@ class Appointment_Service extends SoapClient {
   }
 
 }
-class_alias("Appointment_Service", "Appointment_x0020_Service");
-?>
+	class Appointment_x0020_Service extends Appointment_Service {}
+	?>

--- a/services/Class_Service.php
+++ b/services/Class_Service.php
@@ -27,9 +27,9 @@ class Class_Service extends SoapClient {
                                     'Staff' => 'Staff',
                                     'Appointment' => 'Appointment',
                                     'ScheduleItem' => 'ScheduleItem',
+                                    'Unavailability' => 'Unavailability',
                                     'Availability' => 'Availability',
                                     'Location' => 'Location',
-                                    'Unavailability' => 'Unavailability',
                                     'AppointmentStatus' => 'AppointmentStatus',
                                     'Client' => 'Client',
                                     'ClientIndex' => 'ClientIndex',
@@ -288,5 +288,5 @@ class Class_Service extends SoapClient {
   }
 
 }
-class_alias("Class_Service", "Class_x0020_Service");
-?>
+	class Class_x0020_Service extends Class_Service {}
+	?>

--- a/services/Client_Service.php
+++ b/services/Client_Service.php
@@ -30,10 +30,10 @@ class Client_Service extends SoapClient {
                                     'Staff' => 'Staff',
                                     'Appointment' => 'Appointment',
                                     'ScheduleItem' => 'ScheduleItem',
+                                    'Unavailability' => 'Unavailability',
                                     'Availability' => 'Availability',
                                     'SessionType' => 'SessionType',
                                     'Location' => 'Location',
-                                    'Unavailability' => 'Unavailability',
                                     'AppointmentStatus' => 'AppointmentStatus',
                                     'Resource' => 'Resource',
                                     'CustomClientField' => 'CustomClientField',
@@ -417,5 +417,5 @@ class Client_Service extends SoapClient {
   }
 
 }
-class_alias("Client_Service", "Client_x0020_Service");
-?>
+	class Client_x0020_Service extends Client_Service {}
+	?>

--- a/services/Data_Service.php
+++ b/services/Data_Service.php
@@ -97,5 +97,5 @@ class Data_Service extends SoapClient {
   }
 
 }
-class_alias("Data_Service", "Data_x0020_Service");
-?>
+	class Data_x0020_Service extends Data_Service {}
+	?>

--- a/services/Finder_Service.php
+++ b/services/Finder_Service.php
@@ -27,9 +27,9 @@ class Finder_Service extends SoapClient {
                                     'Staff' => 'Staff',
                                     'Appointment' => 'Appointment',
                                     'ScheduleItem' => 'ScheduleItem',
+                                    'Unavailability' => 'Unavailability',
                                     'Availability' => 'Availability',
                                     'SessionType' => 'SessionType',
-                                    'Unavailability' => 'Unavailability',
                                     'AppointmentStatus' => 'AppointmentStatus',
                                     'Client' => 'Client',
                                     'ClientIndex' => 'ClientIndex',
@@ -50,21 +50,21 @@ class Finder_Service extends SoapClient {
                                     'FinderCheckoutShoppingCart' => 'FinderCheckoutShoppingCart',
                                     'FinderCheckoutShoppingCartRequest' => 'FinderCheckoutShoppingCartRequest',
                                     'PaymentInfo' => 'PaymentInfo',
-                                    'CompInfo' => 'CompInfo',
-                                    'TrackDataInfo' => 'TrackDataInfo',
-                                    'StoredCardInfo' => 'StoredCardInfo',
                                     'DebitAccountInfo' => 'DebitAccountInfo',
+                                    'CompInfo' => 'CompInfo',
+                                    'StoredCardInfo' => 'StoredCardInfo',
                                     'CreditCardInfo' => 'CreditCardInfo',
+                                    'TrackDataInfo' => 'TrackDataInfo',
                                     'FinderCheckoutShoppingCartResponse' => 'FinderCheckoutShoppingCartResponse',
                                     'FinderCheckoutShoppingCartResult' => 'FinderCheckoutShoppingCartResult',
                                     'ShoppingCart' => 'ShoppingCart',
                                     'CartItem' => 'CartItem',
                                     'Item' => 'Item',
-                                    'Package' => 'Package',
-                                    'Service' => 'Service',
                                     'Product' => 'Product',
                                     'Color' => 'Color',
                                     'Size' => 'Size',
+                                    'Service' => 'Service',
+                                    'Package' => 'Package',
                                     'Tip' => 'Tip',
                                     'Class' => 'Class',
                                     'Visit' => 'Visit',
@@ -197,5 +197,5 @@ class Finder_Service extends SoapClient {
   }
 
 }
-class_alias("Finder_Service", "Finder_x0020_Service");
-?>
+	class Finder_x0020_Service extends Finder_Service {}
+	?>

--- a/services/Sale_Service.php
+++ b/services/Sale_Service.php
@@ -23,13 +23,13 @@ class Sale_Service extends SoapClient {
                                     'Staff' => 'Staff',
                                     'Appointment' => 'Appointment',
                                     'ScheduleItem' => 'ScheduleItem',
+                                    'Unavailability' => 'Unavailability',
                                     'Availability' => 'Availability',
                                     'SessionType' => 'SessionType',
                                     'ActionCode' => 'ActionCode',
                                     'Program' => 'Program',
                                     'ScheduleType' => 'ScheduleType',
                                     'Location' => 'Location',
-                                    'Unavailability' => 'Unavailability',
                                     'AppointmentStatus' => 'AppointmentStatus',
                                     'Client' => 'Client',
                                     'ClientIndex' => 'ClientIndex',
@@ -48,16 +48,16 @@ class Sale_Service extends SoapClient {
                                     'Size' => 'Size',
                                     'Color' => 'Color',
                                     'Item' => 'Item',
-                                    'Package' => 'Package',
-                                    'Service' => 'Service',
                                     'Product' => 'Product',
+                                    'Service' => 'Service',
+                                    'Package' => 'Package',
                                     'Tip' => 'Tip',
                                     'PaymentInfo' => 'PaymentInfo',
-                                    'CompInfo' => 'CompInfo',
-                                    'TrackDataInfo' => 'TrackDataInfo',
-                                    'StoredCardInfo' => 'StoredCardInfo',
                                     'DebitAccountInfo' => 'DebitAccountInfo',
+                                    'CompInfo' => 'CompInfo',
+                                    'StoredCardInfo' => 'StoredCardInfo',
                                     'CreditCardInfo' => 'CreditCardInfo',
+                                    'TrackDataInfo' => 'TrackDataInfo',
                                     'CheckoutShoppingCartResponse' => 'CheckoutShoppingCartResponse',
                                     'CheckoutShoppingCartResult' => 'CheckoutShoppingCartResult',
                                     'GetSales' => 'GetSales',
@@ -231,5 +231,5 @@ class Sale_Service extends SoapClient {
   }
 
 }
-class_alias("Sale_Service", "Sale_x0020_Service");
-?>
+	class Sale_x0020_Service extends Sale_Service {}
+	?>

--- a/services/Site_Service.php
+++ b/services/Site_Service.php
@@ -176,5 +176,5 @@ class Site_Service extends SoapClient {
   }
 
 }
-class_alias("Site_Service", "Site_x0020_Service");
-?>
+	class Site_x0020_Service extends Site_Service {}
+	?>

--- a/services/Staff_Service.php
+++ b/services/Staff_Service.php
@@ -35,8 +35,8 @@ class Staff_Service extends SoapClient {
                                     'ScheduleItem' => 'ScheduleItem',
                                     'Appointment' => 'Appointment',
                                     'AppointmentStatus' => 'AppointmentStatus',
-                                    'Availability' => 'Availability',
                                     'Unavailability' => 'Unavailability',
+                                    'Availability' => 'Availability',
                                     'GetStaffPermissions' => 'GetStaffPermissions',
                                     'GetStaffPermissionsRequest' => 'GetStaffPermissionsRequest',
                                     'GetStaffPermissionsResponse' => 'GetStaffPermissionsResponse',
@@ -103,5 +103,5 @@ class Staff_Service extends SoapClient {
   }
 
 }
-class_alias("Staff_Service", "Staff_x0020_Service");
-?>
+	class Staff_x0020_Service extends Staff_Service {}
+	?>


### PR DESCRIPTION
Is there any reason to use class_alias over extends to fix the space issue in the service names?  As far as I can tell, this is the only reason the library isn't compatible with PHP < 5.2.  I've tried this out and it seems to work.  
